### PR TITLE
[flang] Added tests related to 'num_images()' changes

### DIFF
--- a/flang/test/Semantics/call10.f90
+++ b/flang/test/Semantics/call10.f90
@@ -185,7 +185,10 @@ module m
                                    ! implicit sync all
     !ERROR: Procedure 'this_image' referenced in pure subprogram 's14' must be pure too
     img = this_image()
-    !ERROR: Procedure 'num_images' referenced in pure subprogram 's14' must be pure too
+
+    ! num_images() is now evaluted as an intrinsic function
+    ! no longer produces an error because
+    ! "All standard intrinsic functions are pure" - 16.1 of the Fortran Standard 2018
     nimgs = num_images()
     i = img                       ! i is ready to use
 

--- a/flang/test/Semantics/num_images.f90
+++ b/flang/test/Semantics/num_images.f90
@@ -1,0 +1,30 @@
+! RUN: %S/test_errors.sh %s %t %f18
+! Check for semantic errors in num_images() function calls
+
+subroutine test
+
+  ! correct calls, should produce no errors
+  print *, num_images()
+  print *, num_images(team_number=1)
+  print *, num_images(1)
+
+  ! incorrectly typed argument
+  ! the error is seen as too many arguments to the num_images() call with no arguments
+  !ERROR: too many actual arguments for intrinsic 'num_images'
+  print *, num_images(3.4)
+
+  ! call with too many arguments
+  !ERROR: too many actual arguments for intrinsic 'num_images'
+  print *, num_images(1, 1)
+
+  ! keyword argument with incorrect type
+  !ERROR: unknown keyword argument to intrinsic 'num_images'
+  print *, num_images(team_number=3.4)
+
+  ! incorrect keyword argument
+  !ERROR: unknown keyword argument to intrinsic 'num_images'
+  print *, num_images(team_numbers=1)
+
+  !TODO: test num_images() calls related to team_type argument
+
+end subroutine


### PR DESCRIPTION
Summary:
I wrote and added a test to check for semantic errors
in calls to 'num_images()'. I also updated a test,
call10.f90, which has a call to num_images() that previously
produced an error. That line of code no longer
produces an error now that num_images() is evaluted
as intrinsic.